### PR TITLE
docs(architecture): add 'kernel thread list' command to Threads section

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -14,6 +14,12 @@ sensor, flight state machine, and pyrotechnic ignition.
 | `baro_task` | `CONFIG_BARO` | Measures pressure/temperature, computes altitude. |
 | `state_machine_task` | `CONFIG_AURORA_STATE_MACHINE` | Runs at 10 Hz. Feeds sensor data into the state machine and fires pyro channels on state transitions. |
 
+### Viewing Threads
+
+To see all currently running threads, run this command on the Zephyr shell:
+
+    kernel thread list
+
 ## Sensor Data Path
 
 It's a tricky situation trying to fetch data from all sensors at the exact same


### PR DESCRIPTION
## Summary

Adds documentation for viewing running threads on the Zephyr shell using the `kernel thread list` command.

This resolves issue #104.

## Changes

- Added new "Viewing Threads" subsection to the Threads section in `doc/architecture.md`
- Documents the `kernel thread list` command for seeing all running threads on the Zephyr shell