### PR TITLE
feat(notify): :sparkles: add powerfail notification

### DIFF
--- a/include/aurora/lib/notify.h
+++ b/include/aurora/lib/notify.h
@@ -38,6 +38,9 @@ struct notify_backend_api {
 
 	/** @brief Signal an error condition. */
 	int (*on_error)(void);
+
+	/** @brief Signal a power failure (or @p recover from a powerfail) */
+	void (*on_powerfail)(int recover);
 };
 
 /**
@@ -87,6 +90,13 @@ int notify_boot(void);
  * @retval 0 on success, or first non-zero return from a backend.
  */
 int notify_state_change(enum sm_state prev, enum sm_state next);
+
+/**
+ * @brief Notify all backends about a powerfail
+ *
+ * @param recover 1 if Power failure is being recovered.
+ */
+void notify_powerfail(int recover);
 
 /**
  * @brief Notify all backends of an error condition.

--- a/lib/notify/led/led.c
+++ b/lib/notify/led/led.c
@@ -18,7 +18,8 @@ static const struct device *pwm_leds = DEVICE_DT_GET(LED_PWM_NODE_ID);
 static const char *led_labels[] = {
 	DT_FOREACH_CHILD_SEP_VARGS(LED_PWM_NODE_ID, DT_PROP_OR, (,), label, NULL)
 };
-const int num_leds = ARRAY_SIZE(led_labels);
+static const int num_leds = ARRAY_SIZE(led_labels);
+static int recovered = 0;
 
 /** @brief Blink with @p delay_on and @p delay_off in ms. */
 static int blink(uint32_t delay_on, uint32_t delay_off)
@@ -96,11 +97,13 @@ static int led_on_boot(void)
 	int rc = 0;
 	int err = 0;
 
+	recovered = 1;
+
 	err = all_leds_on(MAX_BRIGHTNESS);
 	if (err)
 		rc = err;
 
-	k_sleep(K_MSEC(200));
+	k_sleep(K_MSEC(500));
 
 	err = all_leds_off();
 	if (err)
@@ -111,12 +114,24 @@ static int led_on_boot(void)
 
 static int led_on_error(void)
 {
-	return all_leds_on(MAX_BRIGHTNESS);
+	return recovered == 1 ? all_leds_on(MAX_BRIGHTNESS) : 0;
+}
+
+static void led_on_powerfail(int recover)
+{
+	recovered = recover;
+
+	if(recover == 0)
+		all_leds_off();
 }
 
 static int led_on_state_change(enum sm_state prev, enum sm_state next)
 {
 	ARG_UNUSED(prev);
+
+	// in powerfail mode
+	if (recovered == 0)
+		return 0;
 
 	switch (next) {
 	case SM_ARMED:
@@ -137,6 +152,7 @@ static const struct notify_backend_api led_api = {
 	.on_boot = led_on_boot,
 	.on_state_change = led_on_state_change,
 	.on_error = led_on_error,
+	.on_powerfail = led_on_powerfail,
 };
 
 NOTIFY_BACKEND_DEFINE(notify_led, &led_api);

--- a/lib/notify/notify.c
+++ b/lib/notify/notify.c
@@ -100,3 +100,14 @@ int notify_error(void)
 	}
 	return rc;
 }
+
+void notify_powerfail(int recover) {
+	STRUCT_SECTION_FOREACH(notify_backend, backend) {
+		if (!backend->api) {
+			LOG_ERR("Backend with NULL api pointer: %p", backend);
+			continue;
+		}
+		if (backend->api->on_powerfail)
+			backend->api->on_powerfail(recover);
+	}
+}

--- a/lib/powerfail/powerfail.c
+++ b/lib/powerfail/powerfail.c
@@ -18,6 +18,10 @@
 #include <aurora/lib/data_logger.h>
 #endif /* CONFIG_DATA_LOGGER */
 
+#if defined(CONFIG_AURORA_NOTIFY)
+#include <aurora/lib/notify.h>
+#endif /* CONFIG_AURORA_NOTIFY */
+
 LOG_MODULE_REGISTER(powerfail, CONFIG_AURORA_POWERFAIL_LOG_LEVEL);
 
 #if defined(CONFIG_DATA_LOGGER)
@@ -48,6 +52,10 @@ static inline void emergency_state_save(void)
 #if defined(CONFIG_DATA_LOGGER)
 	data_logger_foreach(emergency_stop_data_logger, NULL);
 #endif /* CONFIG_DATA_LOGGER */
+
+#if defined(CONFIG_AURORA_NOTIFY)
+	notify_powerfail(0);
+#endif /* CONFIG_AURORA_NOTIFY */
 }
 
 static inline void emergency_state_recover(void)
@@ -55,6 +63,10 @@ static inline void emergency_state_recover(void)
 #if defined(CONFIG_DATA_LOGGER)
 	data_logger_foreach(emergency_recover_data_logger, NULL);
 #endif /* CONFIG_DATA_LOGGER */
+
+#if defined(CONFIG_AURORA_NOTIFY)
+	notify_powerfail(1);
+#endif /* CONFIG_AURORA_NOTIFY */
 }
 
 static void powerfail_isr(const struct device *dev, struct gpio_callback *cb,


### PR DESCRIPTION
This PR is preparation for the Multimeter Launch on 18/04/2026.

- add a notification for powerfail and power recovery
- led will not blink while powerfail is assumed (use for arm aswell)
- buzzer will still do buzzer things