### PR TITLE
fix(sensor): :bug: add imu and baro watchdogs

### DIFF
--- a/include/aurora/lib/baro.h
+++ b/include/aurora/lib/baro.h
@@ -62,6 +62,31 @@ int baro_measure(const struct device *dev);
  */
 int baro_init(const struct device *dev);
 
+#if defined(CONFIG_BARO_WATCHDOG)
+/**
+ * @brief Run the baro stall watchdog. Never returns.
+ *
+ * Intended as the post-init body of the baro thread when the baro is driven
+ * by a hardware data-ready trigger (no polling loop).
+ */
+void baro_watchdog_run(void);
+
+/**
+ * @brief Attempt to recover a stalled barometer.
+ *
+ * Re-applies @c CONFIG_BARO_WATCHDOG_RECOVERY_HZ to the sensor and re-arms
+ * the data-ready trigger. Intended to recover from a soft-reset caused by a
+ * power-rail transient.
+ *
+ * @param dev Pointer to the baro device.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if @p dev is NULL.
+ * @retval -errno from the underlying sensor API on failure.
+ */
+int baro_recover(const struct device *dev);
+#endif /* CONFIG_BARO_WATCHDOG */
+
 /**
  * @brief Set the ground-level reference pressure.
  *

--- a/include/aurora/lib/imu.h
+++ b/include/aurora/lib/imu.h
@@ -73,6 +73,31 @@ int imu_set_sampling_freq(const struct device *dev, int sampling_rate_hz);
  */
 int imu_init(const struct device *dev);
 
+#if defined(CONFIG_IMU_WATCHDOG)
+/**
+ * @brief Run the IMU stall watchdog. Never returns.
+ *
+ * Intended as the post-init body of the IMU thread when the IMU is driven by
+ * a hardware data-ready trigger (no polling loop).
+ */
+void imu_watchdog_run(void);
+
+/**
+ * @brief Attempt to recover a stalled IMU.
+ *
+ * Re-applies @c CONFIG_IMU_WATCHDOG_RECOVERY_HZ to the accelerometer and
+ * gyroscope and re-arms the data-ready trigger. Intended to recover from a
+ * soft-reset caused by a power-rail transient.
+ *
+ * @param dev Pointer to the IMU device.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if @p dev is NULL.
+ * @retval -errno from the underlying sensor API on failure.
+ */
+int imu_recover(const struct device *dev);
+#endif /* CONFIG_IMU_WATCHDOG */
+
 /**
  * @brief calculate the average acceleration from IMU sensor values in m/s^2.
  *

--- a/include/aurora/lib/sensor_watchdog.h
+++ b/include/aurora/lib/sensor_watchdog.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025-2026 Auxspace e.V.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef APP_LIB_SENSOR_WATCHDOG_H_
+#define APP_LIB_SENSOR_WATCHDOG_H_
+
+#include <stdint.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/atomic.h>
+
+/**
+ * @defgroup lib_sensor_watchdog Sensor stall watchdog
+ * @ingroup lib
+ * @{
+ *
+ * @brief Generic publish-stall watchdog for trigger-mode sensors.
+ *
+ * Sensors that publish their readings via zbus on a hardware data-ready
+ * interrupt can silently stop producing samples if the chip soft-resets
+ * (e.g. from a power-rail transient). This helper records the time of the
+ * most recent publish and, on a periodic check, invokes a sensor-specific
+ * recovery callback when the publish age exceeds a timeout.
+ *
+ * Usage pattern:
+ *   1. Define a static @ref sensor_watchdog with timeout, period, and a
+ *      sensor-specific @c recover callback.
+ *   2. After the device init succeeds, set @c dev and call
+ *      @ref sensor_watchdog_init to seed the publish clock.
+ *   3. Call @ref sensor_watchdog_mark_publish on every successful publish.
+ *   4. Have a thread call @ref sensor_watchdog_run, which never returns.
+ */
+
+/**
+ * @brief Watchdog state and configuration for a single sensor.
+ *
+ * Configuration fields (@c name, @c dev, @c timeout_ms, @c period_ms,
+ * @c recover) are written by the owner before @ref sensor_watchdog_init.
+ * @c last_pub_ms is internal.
+ */
+struct sensor_watchdog {
+	const char *name;                            /**< Used in log messages. */
+	const struct device *dev;                    /**< Sensor device passed to @c recover. */
+	uint32_t timeout_ms;                         /**< Stall threshold. */
+	uint32_t period_ms;                          /**< Check cadence. */
+	int (*recover)(const struct device *dev);    /**< Sensor-specific recovery. */
+	atomic_t last_pub_ms;                        /**< Internal: last publish uptime (ms). */
+};
+
+/**
+ * @brief Seed the publish clock.
+ *
+ * Call once after the underlying sensor has initialized. Without this seed
+ * the watchdog would trip immediately on first run.
+ */
+void sensor_watchdog_init(struct sensor_watchdog *wd);
+
+/**
+ * @brief Record a successful publish.
+ *
+ * Safe to call from interrupt or workqueue context.
+ */
+void sensor_watchdog_mark_publish(struct sensor_watchdog *wd);
+
+/**
+ * @brief Milliseconds since the last @ref sensor_watchdog_mark_publish call.
+ *
+ * Wrap-safe over @c k_uptime_get_32. Returns time-since-init until the first
+ * publish.
+ */
+uint32_t sensor_watchdog_age_ms(const struct sensor_watchdog *wd);
+
+/**
+ * @brief Watchdog thread entry. Never returns.
+ *
+ * Sleeps @c period_ms, checks the publish age, calls @c recover when the age
+ * exceeds @c timeout_ms, and logs the outcome.
+ */
+void sensor_watchdog_run(struct sensor_watchdog *wd);
+
+/** @} */
+
+#endif /* APP_LIB_SENSOR_WATCHDOG_H_ */

--- a/lib/sensor/CMakeLists.txt
+++ b/lib/sensor/CMakeLists.txt
@@ -3,6 +3,10 @@
 
 zephyr_library()
 
+if(CONFIG_IMU_WATCHDOG OR CONFIG_BARO_WATCHDOG)
+    zephyr_library_sources(sensor_watchdog.c)
+endif()
+
 if(CONFIG_IMU)
     zephyr_library_sources(imu.c)
 endif()

--- a/lib/sensor/Kconfig
+++ b/lib/sensor/Kconfig
@@ -29,6 +29,44 @@ config IMU_TRIGGER
 		This option enables functionality for the IMU
 		to run triggers in an interrupt context.
 
+config IMU_WATCHDOG
+	bool "IMU stall watchdog (trigger mode)"
+	depends on IMU && IMU_TRIGGER
+	default y
+	help
+	  Periodically check that the IMU is still publishing samples on the
+	  zbus channel. If no sample arrives within IMU_WATCHDOG_TIMEOUT_MS,
+	  re-apply the configured ODR and re-arm the data-ready trigger. Acts
+	  as a safety net against IMU soft-resets caused by power-rail
+	  transients (e.g. cap-pyro arming inrush).
+
+config IMU_WATCHDOG_TIMEOUT_MS
+	int "IMU stall watchdog timeout (ms)"
+	depends on IMU_WATCHDOG
+	default 200
+	range 50 10000
+	help
+	  Maximum allowed time between two consecutive IMU samples before the
+	  watchdog declares the IMU stalled and triggers recovery.
+
+config IMU_WATCHDOG_PERIOD_MS
+	int "IMU stall watchdog check period (ms)"
+	depends on IMU_WATCHDOG
+	default 100
+	range 10 1000
+	help
+	  How often the watchdog thread wakes up to check the publish age.
+
+config IMU_WATCHDOG_RECOVERY_HZ
+	int "IMU sampling frequency (Hz) re-applied during watchdog recovery"
+	depends on IMU_WATCHDOG
+	default 104
+	range 1 1000
+	help
+	  ODR re-applied to the accelerometer and gyroscope when the watchdog
+	  attempts recovery. Must match the IMU's intended operating ODR
+	  (which is normally set by the device tree). Defaults to 104 Hz.
+
 # Only show frequency options when IMU is enabled
 choice IMU_FREQUENCY
 	prompt "IMU update frequency (Hz)"
@@ -137,6 +175,44 @@ config BARO_TRIGGER
 	help
 		This option enables functionality for barometric pressure
 		sensors to run triggers in an interrupt context.
+
+config BARO_WATCHDOG
+	bool "Baro stall watchdog (trigger mode)"
+	depends on BARO && BARO_TRIGGER
+	default y
+	help
+	  Periodically check that the barometer is still publishing samples on
+	  the zbus channel. If no sample arrives within BARO_WATCHDOG_TIMEOUT_MS,
+	  re-apply the configured ODR and re-arm the data-ready trigger. Acts as
+	  a safety net against baro soft-resets caused by power-rail transients
+	  (e.g. cap-pyro arming inrush).
+
+config BARO_WATCHDOG_TIMEOUT_MS
+	int "Baro stall watchdog timeout (ms)"
+	depends on BARO_WATCHDOG
+	default 200
+	range 50 10000
+	help
+	  Maximum allowed time between two consecutive baro samples before the
+	  watchdog declares the baro stalled and triggers recovery.
+
+config BARO_WATCHDOG_PERIOD_MS
+	int "Baro stall watchdog check period (ms)"
+	depends on BARO_WATCHDOG
+	default 100
+	range 10 1000
+	help
+	  How often the watchdog thread wakes up to check the publish age.
+
+config BARO_WATCHDOG_RECOVERY_HZ
+	int "Baro sampling frequency (Hz) re-applied during watchdog recovery"
+	depends on BARO_WATCHDOG
+	default 100
+	range 1 1000
+	help
+	  ODR re-applied to the barometer when the watchdog attempts recovery.
+	  Must match the baro's intended operating ODR (which is normally set
+	  by the device tree). Defaults to 100 Hz (LPS22HH).
 
 # Only show frequency options when BARO is enabled
 choice BARO_FREQUENCY

--- a/lib/sensor/baro.c
+++ b/lib/sensor/baro.c
@@ -19,6 +19,9 @@
 #include <zephyr/zbus/zbus.h>
 
 #include <aurora/lib/baro.h>
+#if defined(CONFIG_BARO_WATCHDOG)
+#include <aurora/lib/sensor_watchdog.h>
+#endif
 
 LOG_MODULE_REGISTER(baro, CONFIG_AURORA_SENSORS_LOG_LEVEL);
 
@@ -28,6 +31,15 @@ ZBUS_CHAN_DEFINE(baro_data_chan,
 		 NULL,
 		 ZBUS_OBSERVERS_EMPTY,
 		 ZBUS_MSG_INIT(0));
+
+#if defined(CONFIG_BARO_WATCHDOG)
+static struct sensor_watchdog baro_wd = {
+	.name = "baro",
+	.timeout_ms = CONFIG_BARO_WATCHDOG_TIMEOUT_MS,
+	.period_ms = CONFIG_BARO_WATCHDOG_PERIOD_MS,
+	.recover = baro_recover,
+};
+#endif
 
 /**
  * @brief Fetch and log accelerometer and gyroscope readings.
@@ -63,8 +75,13 @@ static int fetch_and_send(const struct device *dev)
 	ret = zbus_chan_pub(&baro_data_chan, &msg, K_NO_WAIT);
 	if (ret != 0) {
 		LOG_ERR("Failed to publish baro data");
+		return ret;
 	}
-	return ret;
+
+#if defined(CONFIG_BARO_WATCHDOG)
+	sensor_watchdog_mark_publish(&baro_wd);
+#endif
+	return 0;
 }
 
 
@@ -126,8 +143,59 @@ int baro_init(const struct device *dev)
 	LOG_DBG("Baro initialized in trigger mode");
 #endif /* CONFIG_BARO_TRIGGER */
 
+#if defined(CONFIG_BARO_WATCHDOG)
+	baro_wd.dev = dev;
+	sensor_watchdog_init(&baro_wd);
+#endif
+
 	return 0;
 }
+
+#if defined(CONFIG_BARO_WATCHDOG)
+void baro_watchdog_run(void)
+{
+	sensor_watchdog_run(&baro_wd);
+}
+
+int baro_recover(const struct device *dev)
+{
+	if (dev == NULL) {
+		return -EINVAL;
+	}
+
+	struct sensor_value freq = {
+		.val1 = CONFIG_BARO_WATCHDOG_RECOVERY_HZ,
+		.val2 = 0,
+	};
+	int rc;
+
+	rc = sensor_attr_set(dev, SENSOR_CHAN_ALL,
+			     SENSOR_ATTR_SAMPLING_FREQUENCY, &freq);
+	if (rc == -ENOTSUP) {
+		/* Some drivers only accept the attribute on specific channels. */
+		rc = sensor_attr_set(dev, SENSOR_CHAN_PRESS,
+				     SENSOR_ATTR_SAMPLING_FREQUENCY, &freq);
+	}
+	if (rc != 0 && rc != -ENOTSUP) {
+		LOG_ERR("baro_recover: ODR set failed (%d)", rc);
+		return rc;
+	}
+
+#if defined(CONFIG_BARO_TRIGGER)
+	struct sensor_trigger trig = {
+		.type = SENSOR_TRIG_DATA_READY,
+		.chan = SENSOR_CHAN_ALL,
+	};
+	rc = sensor_trigger_set(dev, &trig, trigger_handler);
+	if (rc != 0) {
+		LOG_ERR("baro_recover: trigger re-arm failed (%d)", rc);
+		return rc;
+	}
+#endif
+
+	return 0;
+}
+#endif /* CONFIG_BARO_WATCHDOG */
 
 /*-----------------------------------------------------------
  * Pressure-to-altitude conversion (ISA troposphere)

--- a/lib/sensor/imu.c
+++ b/lib/sensor/imu.c
@@ -18,6 +18,9 @@
 #include <zephyr/zbus/zbus.h>
 
 #include <aurora/lib/imu.h>
+#if defined(CONFIG_IMU_WATCHDOG)
+#include <aurora/lib/sensor_watchdog.h>
+#endif
 
 #ifndef M_PI
 #define M_PI ((double)3.1415926535)
@@ -31,6 +34,15 @@ ZBUS_CHAN_DEFINE(imu_data_chan,
 		 NULL,
 		 ZBUS_OBSERVERS_EMPTY,
 		 ZBUS_MSG_INIT(0));
+
+#if defined(CONFIG_IMU_WATCHDOG)
+static struct sensor_watchdog imu_wd = {
+	.name = "imu",
+	.timeout_ms = CONFIG_IMU_WATCHDOG_TIMEOUT_MS,
+	.period_ms = CONFIG_IMU_WATCHDOG_PERIOD_MS,
+	.recover = imu_recover,
+};
+#endif
 
 /**
  * @brief Convert a Zephyr sensor_value to a double.
@@ -77,8 +89,13 @@ static int fetch_and_send(const struct device *dev)
 	ret = zbus_chan_pub(&imu_data_chan, &msg, K_NO_WAIT);
 	if (ret != 0) {
 		LOG_ERR("Failed to publish IMU data");
+		return ret;
 	}
-	return ret;
+
+#if defined(CONFIG_IMU_WATCHDOG)
+	sensor_watchdog_mark_publish(&imu_wd);
+#endif
+	return 0;
 }
 
 #if defined(CONFIG_IMU_TRIGGER)
@@ -136,8 +153,61 @@ int imu_init(const struct device *dev)
 	run_trigger_mode(dev);
 #endif
 
+#if defined(CONFIG_IMU_WATCHDOG)
+	imu_wd.dev = dev;
+	sensor_watchdog_init(&imu_wd);
+#endif
+
 	return 0;
 }
+
+#if defined(CONFIG_IMU_WATCHDOG)
+void imu_watchdog_run(void)
+{
+	sensor_watchdog_run(&imu_wd);
+}
+
+int imu_recover(const struct device *dev)
+{
+	if (dev == NULL) {
+		return -EINVAL;
+	}
+
+	struct sensor_value freq = {
+		.val1 = CONFIG_IMU_WATCHDOG_RECOVERY_HZ,
+		.val2 = 0,
+	};
+	int rc;
+
+	rc = sensor_attr_set(dev, SENSOR_CHAN_ACCEL_XYZ,
+			     SENSOR_ATTR_SAMPLING_FREQUENCY, &freq);
+	if (rc != 0 && rc != -ENOTSUP) {
+		LOG_ERR("imu_recover: accel ODR set failed (%d)", rc);
+		return rc;
+	}
+
+	rc = sensor_attr_set(dev, SENSOR_CHAN_GYRO_XYZ,
+			     SENSOR_ATTR_SAMPLING_FREQUENCY, &freq);
+	if (rc != 0 && rc != -ENOTSUP) {
+		LOG_ERR("imu_recover: gyro ODR set failed (%d)", rc);
+		return rc;
+	}
+
+#if defined(CONFIG_IMU_TRIGGER)
+	struct sensor_trigger trig = {
+		.type = SENSOR_TRIG_DATA_READY,
+		.chan = SENSOR_CHAN_ACCEL_XYZ,
+	};
+	rc = sensor_trigger_set(dev, &trig, trigger_handler);
+	if (rc != 0) {
+		LOG_ERR("imu_recover: trigger re-arm failed (%d)", rc);
+		return rc;
+	}
+#endif
+
+	return 0;
+}
+#endif /* CONFIG_IMU_WATCHDOG */
 
 /* imu_sensor_value_to_acceleration – see imu.h */
 int imu_sensor_value_to_acceleration(const struct imu_data *data, double *acc_out)

--- a/lib/sensor/sensor_watchdog.c
+++ b/lib/sensor/sensor_watchdog.c
@@ -1,0 +1,59 @@
+/**
+ * @file sensor_watchdog.c
+ * @brief Generic publish-stall watchdog for trigger-mode sensors.
+ *
+ * Copyright (c) 2025-2026, Auxspace e.V.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/atomic.h>
+
+#include <aurora/lib/sensor_watchdog.h>
+
+LOG_MODULE_REGISTER(sensor_watchdog, CONFIG_AURORA_SENSORS_LOG_LEVEL);
+
+void sensor_watchdog_init(struct sensor_watchdog *wd)
+{
+	atomic_set(&wd->last_pub_ms, (atomic_val_t)k_uptime_get_32());
+}
+
+void sensor_watchdog_mark_publish(struct sensor_watchdog *wd)
+{
+	atomic_set(&wd->last_pub_ms, (atomic_val_t)k_uptime_get_32());
+}
+
+uint32_t sensor_watchdog_age_ms(const struct sensor_watchdog *wd)
+{
+	uint32_t last = (uint32_t)atomic_get(&wd->last_pub_ms);
+	return k_uptime_get_32() - last;
+}
+
+void sensor_watchdog_run(struct sensor_watchdog *wd)
+{
+	while (1) {
+		k_sleep(K_MSEC(wd->period_ms));
+
+		uint32_t age_ms = sensor_watchdog_age_ms(wd);
+		if (age_ms <= wd->timeout_ms) {
+			continue;
+		}
+
+		LOG_WRN("%s stalled (%u ms since last sample); recovering",
+			wd->name, age_ms);
+
+		int rc = wd->recover ? wd->recover(wd->dev) : -ENOSYS;
+		if (rc != 0) {
+			LOG_ERR("%s recovery failed (%d)", wd->name, rc);
+		} else {
+			LOG_INF("%s recovery succeeded", wd->name);
+			/* Restart the clock so the next miss is timed from
+			 * here rather than from before the stall. The recover
+			 * callback may also do this, but we make it explicit.
+			 */
+			sensor_watchdog_mark_publish(wd);
+		}
+	}
+}

--- a/sensor_board/src/main.c
+++ b/sensor_board/src/main.c
@@ -160,6 +160,7 @@ void imu_task(void *, void *, void *)
 		return;
 	}
 	imu_active = true;
+	LOG_INF("IMU ready");
 
 #if !defined(CONFIG_IMU_TRIGGER)
 	const int imu_hz = CONFIG_IMU_FREQUENCY_VALUE;
@@ -171,9 +172,9 @@ void imu_task(void *, void *, void *)
 		}
 		k_sleep(K_MSEC(1000 / imu_hz));
 	}
-#endif /* !CONFIG_IMU_TRIGGER */
-
-	LOG_INF("IMU ready");
+#elif defined(CONFIG_IMU_WATCHDOG)
+	imu_watchdog_run();
+#endif
 }
 
 /* Create the IMU task (inactive unless CONFIG_IMU=y) */
@@ -200,6 +201,7 @@ void baro_task(void *, void *, void *)
 		return;
 	}
 	baro_active = true;
+	LOG_INF("Baro ready");
 
 #if !defined(CONFIG_BARO_TRIGGER)
 	const int baro_hz = CONFIG_BARO_FREQUENCY_VALUE;
@@ -211,9 +213,9 @@ void baro_task(void *, void *, void *)
 
 		k_sleep(K_MSEC(1000 / baro_hz));
 	}
-#endif /* !CONFIG_BARO_TRIGGER */
-
-	LOG_INF("Baro ready");
+#elif defined(CONFIG_BARO_WATCHDOG)
+	baro_watchdog_run();
+#endif
 }
 
 /* Create the BARO task */


### PR DESCRIPTION
Possible explanation to the IMU stalls after ~500s in flight_logs/multimeter/2026-05-03/flight2:

IMU stops sampling ~100µs before state machine goes to ARMED. The cap-pyro starts charging at ARM.
The inrush at that instant likely browned out the IMU rail just enough to soft-reset its ODR/CTRL regs into power-down, or latched its INT line.
After that, no DRDY edges -> no trigger_handler calls -> no zbus publishes. Silently, no LOG_ERR because nothing in the firmware notices.

Workaround: sensor-watchdog

Closes #131 