### PR TITLE
build(config): :sparkles: improve config error handling

### DIFF
--- a/lib/notify/buzzer/buzzer.c
+++ b/lib/notify/buzzer/buzzer.c
@@ -30,6 +30,14 @@
 
 LOG_MODULE_REGISTER(notify_buzzer, CONFIG_AURORA_NOTIFY_LOG_LEVEL);
 
+/* Build-time dependency: AURORA_NOTIFY_BUZZER needs the board/app to select a
+ * pwm-buzzer (auxspaceev,pwm-buzzer) via the 'auxspace,buzzer' chosen node. */
+#if !DT_HAS_CHOSEN(auxspace_buzzer)
+#error "CONFIG_AURORA_NOTIFY_BUZZER requires DT chosen 'auxspace,buzzer' to point at a pwm-buzzer (auxspaceev,pwm-buzzer) node."
+#endif
+BUILD_ASSERT(DT_NODE_HAS_STATUS(DT_CHOSEN(auxspace_buzzer), okay),
+	     "the 'auxspace,buzzer' chosen node must have status \"okay\"");
+
 static const struct pwm_dt_spec buzzer =
 	PWM_DT_SPEC_GET(DT_CHOSEN(auxspace_buzzer));
 

--- a/lib/notify/led/led.c
+++ b/lib/notify/led/led.c
@@ -23,7 +23,16 @@ LOG_MODULE_REGISTER(notify_led, CONFIG_AURORA_NOTIFY_LOG_LEVEL);
 
 #define MAX_BRIGHTNESS 100
 
+/* Build-time dependency: AURORA_NOTIFY_LED needs the board/app to select a
+ * pwm-leds device via the 'auxspace,led' chosen node. */
+#if !DT_HAS_CHOSEN(auxspace_led)
+#error "CONFIG_AURORA_NOTIFY_LED requires DT chosen 'auxspace,led' to point at a pwm-leds node."
+#endif
+
 #define LED_PWM_NODE_ID	 DT_CHOSEN(auxspace_led)
+
+BUILD_ASSERT(DT_NODE_HAS_STATUS(LED_PWM_NODE_ID, okay),
+	     "the 'auxspace,led' chosen node must have status \"okay\"");
 
 static const struct device *pwm_leds = DEVICE_DT_GET(LED_PWM_NODE_ID);
 static const char *led_labels[] = {

--- a/lib/powerfail/powerfail.c
+++ b/lib/powerfail/powerfail.c
@@ -38,6 +38,15 @@ static inline void emergency_recover_data_logger(struct data_logger *logger,
 }
 #endif /* CONFIG_DATA_LOGGER */
 
+/* Build-time dependency: AURORA_POWERFAIL needs the board/app to select the
+ * power-fail monitor input (a "gpios" property) via the 'auxspace,pfm' chosen
+ * node. */
+#if !DT_HAS_CHOSEN(auxspace_pfm)
+#error "CONFIG_AURORA_POWERFAIL requires DT chosen 'auxspace,pfm' to point at a node with a gpios property (the power-fail monitor input)."
+#endif
+BUILD_ASSERT(DT_NODE_HAS_STATUS(DT_CHOSEN(auxspace_pfm), okay),
+	     "the 'auxspace,pfm' chosen node must have status \"okay\"");
+
 static const struct gpio_dt_spec pfail_pin =
     GPIO_DT_SPEC_GET(DT_CHOSEN(auxspace_pfm), gpios);
 

--- a/sensor_board/src/main.c
+++ b/sensor_board/src/main.c
@@ -31,6 +31,13 @@
 
 #if defined(CONFIG_PYRO)
 #include <aurora/drivers/pyro.h>
+/* Build-time dependency: the state machine fires a pyro device selected via the
+ * 'auxspace,pyro' chosen node. */
+#if !DT_HAS_CHOSEN(auxspace_pyro)
+#error "CONFIG_PYRO requires DT chosen 'auxspace,pyro' to point at a pyro device node."
+#endif
+BUILD_ASSERT(DT_NODE_HAS_STATUS(DT_CHOSEN(auxspace_pyro), okay),
+	     "the 'auxspace,pyro' chosen node must have status \"okay\"");
 #endif /* CONFIG_PYRO */
 
 #if defined(CONFIG_DATA_LOGGER_BIN)
@@ -109,6 +116,13 @@ static bool sm_active = false; /**< True once the state machine thread has initi
  *                     IMU TASK
  * ============================================================ */
 #if defined(CONFIG_IMU) && !defined(CONFIG_AURORA_FAKE_SENSORS)
+/* Build-time dependency: the IMU task fetches its device from the
+ * 'auxspace,imu' chosen node. */
+#if !DT_HAS_CHOSEN(auxspace_imu)
+#error "CONFIG_IMU requires DT chosen 'auxspace,imu' to point at an IMU sensor node."
+#endif
+BUILD_ASSERT(DT_NODE_HAS_STATUS(DT_CHOSEN(auxspace_imu), okay),
+	     "the 'auxspace,imu' chosen node must have status \"okay\"");
 /**
  * @brief IMU polling thread.
  *


### PR DESCRIPTION
## Description

Look for chosen node in DT during build-time to counteract ugly error messages and compiler errors on misconfigured firmware.

## Related Issues

Closes #162 

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behavior change
- [x] `build` / `ci` — build system or CI changes
- [ ] `tests` — adding or updating tests

## Testing

How was this tested? Which boards / targets were used?

- [x] `west twister -T tests -v --inline-logs` passes
- [x] Tested on hardware: micromter/esp32s3/procpu
- [x] Docs build without warnings: `cd doc && make html`

## Checklist

- [x] Commit messages follow the [Conventional Commits + gitmoji](../CONTRIBUTING.md#commit-messages) style
- [x] New or changed public APIs have Doxygen comments
- [x] No unrelated changes are included
