### PR TITLE
feat(shell): :sparkles: New / Reworked command to force state transit…

### DIFF
--- a/include/aurora/lib/state/state.h
+++ b/include/aurora/lib/state/state.h
@@ -129,6 +129,13 @@ enum sm_type sm_get_type(void);
  */
 void sm_get_inputs(struct sm_inputs *out);
 
+/**
+ * @brief Update the state machine with force. No further checks are done.
+ *
+ * @param transition_to State to transition.
+ */
+void sm_update_force(enum sm_state transition_to);
+
 /** @} */
 
 #endif /* APP_LIB_STATE_H_ */

--- a/lib/state/simple_state.c
+++ b/lib/state/simple_state.c
@@ -482,6 +482,13 @@ void sm_update(const struct sm_inputs *inputs)
 #endif /* CONFIG_FILTER */
 }
 
+/* sm_update_force – see state.h */
+void sm_update_force(enum sm_state transition_to)
+{
+	SM_TRANSITION(transition_to);
+}
+
+
 /*-----------------------------------------------------------
  * Getter
  *----------------------------------------------------------*/

--- a/lib/state/state_shell.c
+++ b/lib/state/state_shell.c
@@ -73,6 +73,9 @@ static enum sm_state forced_target_state;
 /** @brief  Callback function to handle the user input for forced state transitions.*/
 static void transition_bypass_cb(const struct shell *sh, uint8_t *data, size_t len, void *user_data)
 {
+	if (len == 0 || data == NULL) return;
+	if (data[0] == '\0') return;
+
 	char ch = tolower((char)data[0]);
 
 	if (ch == 'y') {

--- a/lib/state/state_shell.c
+++ b/lib/state/state_shell.c
@@ -12,6 +12,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 #include <zephyr/shell/shell.h>
 
@@ -67,6 +68,28 @@ static int parse_state(const char *name, enum sm_state *out)
  * Commands
  *----------------------------------------------------------*/
 
+static enum sm_state forced_target_state;
+
+/** @brief  Callback function to handle the user input for forced state transitions.*/
+static void transition_bypass_cb(const struct shell *sh, uint8_t *data, size_t len, void *user_data)
+{
+	char ch = tolower((char)data[0]);
+
+	if (ch == 'y') {
+		shell_print(sh, "Transitioning to state %s...", sm_state_str(forced_target_state));
+
+		sm_update_force(forced_target_state);
+
+	} else if (ch == 'n') {
+		shell_warn(sh, "Transition aborted by user.");
+	} else {
+		shell_warn(sh, "Invalid input. Please enter 'y' or 'n': ");
+		return;
+	}
+
+	shell_set_bypass(sh, NULL, NULL);
+}
+
 /** @brief Show state machine type and current state. */
 static int cmd_status(const struct shell *sh, size_t argc, char **argv)
 {
@@ -109,19 +132,21 @@ static int cmd_transition(const struct shell *sh, size_t argc, char **argv)
 		return 0;
 	}
 
-	/*
-	 * Re-initialize to IDLE then, if the target is not IDLE, we
-	 * cannot jump arbitrarily because the SM has no public setter.
-	 * Instead we deinit + init which lands us in IDLE.
-	 */
-	sm_deinit();
+	forced_target_state = target;
+
+	 if (target != SM_IDLE) {
+		shell_warn(sh, "Only transitions to IDLE are safe.");
+		shell_warn(sh, "State transitioning can result in pyro charges firing. Continue? (y/n)");
+
+		// Unblock the shell
+		shell_set_bypass(sh, transition_bypass_cb, NULL);
+		return 0;
+	 }
+
 	shell_print(sh, "%s -> %s (forced via shell)",
 		    sm_state_str(current), argv[1]);
+	sm_update_force(target);
 
-	if (target != SM_IDLE) {
-		shell_warn(sh, "Only transitions to IDLE are safe; "
-			   "state machine has been reset to IDLE");
-	}
 
 	return 0;
 }


### PR DESCRIPTION
…ions via shell

## Description

What does this PR do and why?
Updates the state_machine shell command to force transitions.
Forcing to IDLE works without a warning.
Forcing to any other state needs a user confirmation.

## Related Issues

Closes #147 

## Type of Change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behavior change
- [ ] `build` / `ci` — build system or CI changes
- [ ] `tests` — adding or updating tests

## Testing

How was this tested? Which boards / targets were used?

- [x] `west twister -T tests -v --inline-logs` passes
- [x] Tested on hardware: Sensor Board v2
- [ ] Docs build without warnings: `cd doc && make html`

## Checklist

- [x] Commit messages follow the [Conventional Commits + gitmoji](../CONTRIBUTING.md#commit-messages) style
- [x] New or changed public APIs have Doxygen comments
- [x] No unrelated changes are included


## Example
```bash
help
...
  state_machine  : State machine commands
uart:~$ state_machine
state_machine - State machine commands
Subcommands:
  status       : Show state machine type and current state
  transition   : Force a state transition (ground test only)
  audit        : Show audit log of state transitions and events
  audit_clear  : Clear the audit log
uart:~$ state_machine status
Type:  simple
State: IDLE
uart:~$ state_machine transition
transition: wrong parameter count
transition - Force a state transition (ground test only)
Subcommands:
  IDLE
  ARMED
  BOOST
  BURNOUT
  APOGEE
  MAIN
  REDUNDANT
  LANDED
  ERROR
uart:~$ state_machine transition APOGEE
Only transitions to IDLE are safe.
State transitioning can result in pyro charges firing. Continue? (y/n)
Transitioning to state APOGEE...
uart:~$ [00:00:37.016,000] <inf> [ 10 audit_writer_th] state_audit: 37006700000  transition   IDLE         APOGEE
[00:00:37.047,000] <inf> [ 10 audit_writer_th] state_audit: 37042300000  transition   APOGEE       MAIN
[00:00:37.016,000] <inf> [ 10 audit_writer_th] state_audit: 37006700000  transition   IDLE         APOGEE
[00:00:37.047,000] <inf> [ 10 audit_writer_th] state_audit: 37042300000  transition   APOGEE       MAIN
uart:~$ [00:00:39.067,000] <inf> [ 10 audit_writer_th] state_audit: 39061500000  transition   MAIN         REDUNDANT
[00:00:39.067,000] <inf> [ 10 audit_writer_th] state_audit: 39061500000  transition   MAIN         REDUNDANT
uart:~$ [00:00:39.595,000] <inf> [ 10 audit_writer_th] state_audit: 39590600000  transition   REDUNDANT    LANDED
[00:00:39.595,000] <inf> [ 10 audit_writer_th] state_audit: 39590600000  transition   REDUNDANT    LANDED
uart:~$ state_machine transition IDLE
LANDED -> IDLE (forced via shell)
uart:~$ [00:00:53.480,000] <inf> [ 10 audit_writer_th] state_audit: 53476100000  transition   LANDED       IDLE
[00:00:53.480,000] <inf> [ 10 audit_writer_th] state_audit: 53476100000  transition   LANDED       IDLE
uart:~$
```