### PR TITLE
State machine include refactoring

### DIFF
--- a/include/aurora/lib/notify.h
+++ b/include/aurora/lib/notify.h
@@ -6,7 +6,7 @@
 #ifndef APP_LIB_NOTIFY_H_
 #define APP_LIB_NOTIFY_H_
 
-#include <aurora/lib/state/simple.h>
+#include <aurora/lib/state/state.h>
 
 /**
  * @defgroup lib_notify Notification library

--- a/include/aurora/lib/powerfail.h
+++ b/include/aurora/lib/powerfail.h
@@ -6,7 +6,7 @@
 #ifndef APP_LIB_POWERFAIL_H_
 #define APP_LIB_POWERFAIL_H_
 
-#include <aurora/lib/state/simple.h>
+#include <aurora/lib/state/state.h>
 
 /**
  * @defgroup lib_powerfail Powerfail mitigation library

--- a/include/aurora/lib/state/internal/simple.h
+++ b/include/aurora/lib/state/internal/simple.h
@@ -3,6 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/*
+ * Backend types for the simple state machine.
+ *
+ * This is an INTERNAL header: it defines the implementation-specific types
+ * that the public API in <aurora/lib/state/state.h> is built on.  The state
+ * core routes it in for you.  Applications must include
+ * <aurora/lib/state/state.h> and never this file directly, so that no code
+ * binds itself to a particular backend.  Direct inclusion is rejected below.
+ */
+#ifndef AURORA_STATE_BACKEND_INTERNAL
+#error "Do not include <aurora/lib/state/internal/simple.h> directly; " \
+       "include <aurora/lib/state/state.h> instead."
+#endif /* AURORA_STATE_BACKEND_INTERNAL */
+
 #ifndef APP_LIB_STATE_SIMPLE_H_
 #define APP_LIB_STATE_SIMPLE_H_
 

--- a/include/aurora/lib/state/state.h
+++ b/include/aurora/lib/state/state.h
@@ -14,11 +14,23 @@
  * @brief AURORA common state machine library for avionics.
  */
 
+/*
+ * The common API below is implemented once by the state core (state.c) and
+ * dispatches to the selected backend through direct calls.  Its signatures
+ * still reference backend-specific types (enum sm_state, struct sm_thresholds,
+ * struct sm_inputs), so the matching backend *types* header is routed in here
+ * by Kconfig.  Those headers live under internal/ and reject direct inclusion:
+ * this is the single, backend-agnostic entry point applications include.
+ * Each backend must define an sm_state enum that includes at least SM_IDLE and
+ * SM_ERROR, which the common error path relies on.
+ */
+#define AURORA_STATE_BACKEND_INTERNAL
 #if defined(CONFIG_SIMPLE_STATE)
-#include <aurora/lib/state/simple.h>
+#include <aurora/lib/state/internal/simple.h>
 #else
 #error "Unknown state machine type! Make sure CONFIG_AURORA_STATE_MACHINE_TYPE is set."
 #endif /* CONFIG_SIMPLE_STATE */
+#undef AURORA_STATE_BACKEND_INTERNAL
 
 /*-----------------------------------------------------------
  * State machine type
@@ -33,7 +45,7 @@
  * can decode it.
  */
 enum sm_type {
-    SM_TYPE_SIMPLE = 0,    /**< @ref aurora/lib/state/simple.h */
+    SM_TYPE_SIMPLE = 0,    /**< Simple backend (lib/state/simple.c). */
     /* SM_TYPE_TWO_STAGE = 1, ... */
 };
 

--- a/lib/state/CMakeLists.txt
+++ b/lib/state/CMakeLists.txt
@@ -3,8 +3,11 @@
 
 zephyr_library()
 
+# Common state machine core (implementation-independent).
+zephyr_library_sources(state.c)
+
 if(CONFIG_SIMPLE_STATE)
-    zephyr_library_sources(simple_state.c)
+    zephyr_library_sources(simple.c)
 endif()
 
 if(CONFIG_AURORA_STATE_MACHINE_AUDIT)

--- a/lib/state/simple.c
+++ b/lib/state/simple.c
@@ -1,6 +1,6 @@
 /**
- * @file simple_state.c
- * @brief Simple 9-state flight state machine implementation.
+ * @file simple.c
+ * @brief Simple 9-state flight state machine backend.
  *
  * Implements the flight state sequence:
  * IDLE -> ARMED -> BOOST -> BURNOUT -> APOGEE -> MAIN -> REDUNDANT -> LANDED / ERROR
@@ -8,53 +8,30 @@
  * State transitions are driven by sensor thresholds and timers.
  * Optionally integrates with the Kalman filter input filtering.
  *
+ * Only the implementation-specific pieces live here: the threshold set,
+ * the per-state transition logic and its timers.  The common lifecycle,
+ * update entry point and error handling are provided by the state core
+ * (state.c); this backend drives it through the helpers in
+ * state_internal.h.
+ *
  * Copyright (c) 2025-2026, Auxspace e.V.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <math.h>
+#include <string.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/spinlock.h>
 
 #include <aurora/lib/state/state.h>
+#include "state_internal.h"
 
 #ifndef M_PI
 #define M_PI ((double)3.1415926535)
 #endif
 
-/**
- * @brief Elevation of the configured up axis from horizontal (degrees).
- *
- * The orientation vector produced by imu_sensor_value_to_orientation()
- * already accounts for @c CONFIG_IMU_UP_AXIS_* by remapping the body
- * "up" axis to local Z, so pitch and yaw alone are sufficient to
- * recover the up-axis tilt:
- *   gz/|g| = cos(pitch) * cos(yaw)
- *
- * @return Elevation in degrees, clamped to [-90, 90].  +90 = up axis
- *         points to the sky, 0 = horizontal, -90 = inverted.
- */
-static inline double sm_orientation_elevation_deg(const double orientation[3])
-{
-	const double deg2rad = M_PI / 180.0;
-	double s = cos(orientation[1] * deg2rad) * cos(orientation[0] * deg2rad);
-	if (s > 1.0)  s = 1.0;
-	if (s < -1.0) s = -1.0;
-	return asin(s) * (180.0 / M_PI);
-}
-
-#if defined(CONFIG_AURORA_STATE_MACHINE_AUDIT)
-#include <aurora/lib/state/audit.h>
-#endif /* CONFIG_AURORA_STATE_MACHINE_AUDIT */
-
-#if defined(CONFIG_FILTER)
-#include <aurora/lib/filter.h>
-static struct filter filter;
-#endif /* CONFIG_FILTER */
-
-LOG_MODULE_REGISTER(simple_state, CONFIG_STATE_MACHINE_LOG_LEVEL);
+LOG_MODULE_DECLARE(state_machine, CONFIG_STATE_MACHINE_LOG_LEVEL);
 
 /*-----------------------------------------------------------
  * Prototypes
@@ -62,26 +39,6 @@ LOG_MODULE_REGISTER(simple_state, CONFIG_STATE_MACHINE_LOG_LEVEL);
 
 /** @brief Initialize all internal Zephyr timers used by the state machine. */
 static void init_timers(void);
-
-/** @brief Stop all running timers and clear the @ref running_timers flags. */
-static void stop_timers(void);
-
-/**
- * @brief Default error handler when no user callback is registered.
- *
- * @param reason Why the state machine entered SM_ERROR.
- * @param args Unused opaque argument (always NULL).
- * @return Always returns -EIO.
- */
-static int fallback_sm_error_handler(enum sm_error_reason reason, void *args);
-
-/**
- * @brief Transition to SM_ERROR and invoke the error callback.
- *
- * Acquires @ref err_lock, sets state to SM_ERROR, records @p reason and
- * calls the registered error callback (or the fallback) with it.
- */
-static void sm_do_error_handling(enum sm_error_reason reason);
 
 /**
  * @brief Check if acceleration and altitude meet ARMED->BOOST thresholds.
@@ -92,30 +49,10 @@ static void sm_do_error_handling(enum sm_error_reason reason);
  */
 static inline bool arm_to_boost_conditions_met(const struct sm_inputs *in);
 
-/**
- * @brief Core state machine update logic.
- *
- * Evaluates sensor inputs against thresholds and timers to determine
- * state transitions.  Called by sm_update() with additional bookkeeping.
- *
- * @param in                Pointer to the current sensor input values.
- * @param previous_altitude Altitude from the previous update cycle (m).
- */
-static inline void _sm_update(const struct sm_inputs *in,
-			      double previous_altitude);
-
 /*-----------------------------------------------------------
  * Internal State
  *----------------------------------------------------------*/
-static enum sm_state current_state = SM_IDLE; /**< Active flight state. */
 static struct sm_thresholds th; /**< Loaded threshold configuration. */
-static struct sm_inputs last_inputs; /**< Last inputs evaluated by _sm_update(). */
-
-static struct k_spinlock err_lock; /**< Spinlock protecting error callback invocation. */
-static struct sm_error_handling_args err_hdl = {
-	.cb = &fallback_sm_error_handler,
-	.args = NULL,
-};
 
 static struct k_timer dt_ab; /**< Duration timer for ARMED->BOOST assertion. */
 static struct k_timer dt_l;  /**< Duration timer for landing velocity assertion. */
@@ -145,16 +82,26 @@ static int running_timers[NUM_TIMERS] = {0}; /**< Per-timer running flag. */
  */
 #define TIMER_EXPIRED(tmr) (k_timer_status_get(tmr) > 0)
 
-#if defined(CONFIG_AURORA_STATE_MACHINE_AUDIT)
-#define SM_TRANSITION(new_state) do {				\
-	sm_audit_transition(current_state, (new_state));	\
-	current_state = (new_state);				\
-} while (0)
-#define SM_EVENT(msg) sm_audit_event(current_state, (msg))
-#else
-#define SM_TRANSITION(new_state) do { current_state = (new_state); } while (0)
-#define SM_EVENT(msg)
-#endif /* CONFIG_AURORA_STATE_MACHINE_AUDIT */
+/**
+ * @brief Elevation of the configured up axis from horizontal (degrees).
+ *
+ * The orientation vector produced by imu_sensor_value_to_orientation()
+ * already accounts for @c CONFIG_IMU_UP_AXIS_* by remapping the body
+ * "up" axis to local Z, so pitch and yaw alone are sufficient to
+ * recover the up-axis tilt:
+ *   gz/|g| = cos(pitch) * cos(yaw)
+ *
+ * @return Elevation in degrees, clamped to [-90, 90].  +90 = up axis
+ *         points to the sky, 0 = horizontal, -90 = inverted.
+ */
+static inline double sm_orientation_elevation_deg(const double orientation[3])
+{
+	const double deg2rad = M_PI / 180.0;
+	double s = cos(orientation[1] * deg2rad) * cos(orientation[0] * deg2rad);
+	if (s > 1.0)  s = 1.0;
+	if (s < -1.0) s = -1.0;
+	return asin(s) * (180.0 / M_PI);
+}
 
 static void init_timers(void)
 {
@@ -168,7 +115,8 @@ static void init_timers(void)
 	memset(running_timers, 0, sizeof(running_timers));
 }
 
-static void stop_timers(void)
+/* sm_backend_stop_timers – see state_internal.h */
+void sm_backend_stop_timers(void)
 {
 	k_timer_stop(&dt_ab);
 	k_timer_stop(&dt_l);
@@ -180,113 +128,46 @@ static void stop_timers(void)
 	memset(running_timers, 0, sizeof(running_timers));
 }
 
-static int fallback_sm_error_handler(enum sm_error_reason reason, void *args)
-{
-	ARG_UNUSED(args);
-	LOG_ERR("State Machine encountered an unrecoverable error (%s)",
-		sm_error_reason_str(reason));
-
-	return -EIO;
-}
-
-/* Why the machine is (or last was) in SM_ERROR.  Recorded by
- * sm_do_error_handling() so re-invocations from the SM_ERROR state keep
- * reporting the original cause to the callback.
- */
-static enum sm_error_reason err_reason = SM_ERR_UNKNOWN;
-
-static void sm_do_error_handling(enum sm_error_reason reason)
-{
-	int ret;
-	k_spinlock_key_t key = k_spin_lock(&err_lock);
-
-	if (current_state != SM_ERROR) {
-		err_reason = reason;
-		SM_TRANSITION(SM_ERROR);
-	}
-
-	if (err_hdl.cb == NULL) {
-		LOG_ERR("No fallback handler defined for state machine errors!");
-		goto out;
-	}
-
-	ret = err_hdl.cb(err_reason, err_hdl.args);
-	if (ret == 0) {
-		SM_EVENT("error mitigated, returning to IDLE");
-		stop_timers();
-		err_reason = SM_ERR_UNKNOWN;
-		SM_TRANSITION(SM_IDLE);
-	} else {
-		LOG_ERR("State Machine error handler failed with code %d", ret);
-	}
-
-out:
-	k_spin_unlock(&err_lock, key);
-}
-
-/*-----------------------------------------------------------
- * Initialization / Deinitialization
- *----------------------------------------------------------*/
-
-/* sm_init – see state.h */
-void sm_init(const struct sm_thresholds *cfg,
-			 struct sm_error_handling_args *sm_err_hdl)
-{
-#if defined(CONFIG_FILTER)
-	int ret = filter_init(&filter);
-	if (ret) {
-		LOG_ERR("Could not initialize filter (%d).", ret);
-		return;
-	}
-#endif /* CONFIG_FILTER */
-
-	th = *(struct sm_thresholds *)cfg;
-	init_timers();
-	current_state = SM_IDLE;
-	err_reason = SM_ERR_UNKNOWN;
-	SM_EVENT("state machine initialized");
-
-	if (sm_err_hdl != NULL) {
-		err_hdl.cb = sm_err_hdl->cb;
-		err_hdl.args = sm_err_hdl->args;
-	}
-}
-
-/* sm_deinit – see state.h */
-void sm_deinit(void)
-{
-	memset(&th, 0, sizeof(th));
-	memset(&last_inputs, 0, sizeof(last_inputs));
-	stop_timers();
-	SM_EVENT("state machine reset");
-	current_state = SM_IDLE;
-	err_reason = SM_ERR_UNKNOWN;
-}
-
-/*-----------------------------------------------------------
- * Helper for ARM -> BOOST conditions
- *----------------------------------------------------------*/
 static inline bool arm_to_boost_conditions_met(const struct sm_inputs *in)
 {
 	return (in->acceleration >= th.T_AB &&
-			in->altitude >= th.T_H);
+		in->altitude >= th.T_H);
 }
 
 /*-----------------------------------------------------------
- * State Machine Update
+ * Initialization / Deinitialization (see state_internal.h)
  *----------------------------------------------------------*/
-static inline void _sm_update(const struct sm_inputs *in,
-			      double previous_altitude)
+
+/* sm_backend_init – see state_internal.h */
+void sm_backend_init(const struct sm_thresholds *cfg)
+{
+	th = *cfg;
+	init_timers();
+}
+
+/* sm_backend_deinit – see state_internal.h */
+void sm_backend_deinit(void)
+{
+	memset(&th, 0, sizeof(th));
+	sm_backend_stop_timers();
+}
+
+/*-----------------------------------------------------------
+ * State Machine Update (see state_internal.h)
+ *----------------------------------------------------------*/
+
+/* sm_backend_step – see state_internal.h */
+void sm_backend_step(const struct sm_inputs *in, double previous_altitude)
 {
 	static int n_oi;
 
 	/* go to IDLE if disarmed */
-	if (!in->armed && current_state != SM_IDLE) {
-		stop_timers();
-		SM_TRANSITION(SM_IDLE);
+	if (!in->armed && sm_get_state() != SM_IDLE) {
+		sm_backend_stop_timers();
+		sm_transition(SM_IDLE);
 	}
 
-	switch (current_state)
+	switch (sm_get_state())
 	{
 
 	/*-----------------------------------------------------------
@@ -296,7 +177,7 @@ static inline void _sm_update(const struct sm_inputs *in,
 		n_oi = 0;
 		if (in->armed && sm_orientation_elevation_deg(in->orientation) >= th.T_OA) {
 			if (in->log_ready) {
-				SM_TRANSITION(SM_ARMED);
+				sm_transition(SM_ARMED);
 			} else {
 				/* Arm conditions are met but the flight log is
 				 * offline.  Refuse to arm so the vehicle never
@@ -305,7 +186,7 @@ static inline void _sm_update(const struct sm_inputs *in,
 				 * operator gets an unmissable field indication
 				 * (LED/buzzer via the app error callback).
 				 */
-				SM_EVENT("arm refused: flight log offline");
+				sm_event("arm refused: flight log offline");
 				sm_do_error_handling(SM_ERR_LOG_OFFLINE);
 			}
 		}
@@ -326,7 +207,7 @@ static inline void _sm_update(const struct sm_inputs *in,
 		if (!in->log_ready) {
 			running_timers[TIMER_DT_AB] = 0;
 			k_timer_stop(&dt_ab);
-			SM_EVENT("arm aborted: flight log offline");
+			sm_event("arm aborted: flight log offline");
 			sm_do_error_handling(SM_ERR_LOG_OFFLINE);
 			break;
 		}
@@ -338,8 +219,8 @@ static inline void _sm_update(const struct sm_inputs *in,
 			/* Go back to IDLE if orientation is bad */
 			running_timers[TIMER_DT_AB] = 0;
 			k_timer_stop(&dt_ab);
-			SM_EVENT("orientation below threshold");
-			SM_TRANSITION(SM_IDLE);
+			sm_event("orientation below threshold");
+			sm_transition(SM_IDLE);
 			break;
 		}
 		n_oi = 0;
@@ -357,9 +238,9 @@ static inline void _sm_update(const struct sm_inputs *in,
 			/* At this point, conditions are met. Is the timer done as well? */
 			if (TIMER_EXPIRED(&dt_ab)) {
 				n_oi = 0;
-				SM_EVENT("orientation, altitude and timing threshold reached");
+				sm_event("orientation, altitude and timing threshold reached");
 				/* Congrats! BOOST detected! */
-				SM_TRANSITION(SM_BOOST);
+				sm_transition(SM_BOOST);
 				k_timer_stop(&dt_ab);
 				running_timers[TIMER_DT_AB] = 0;
 			}
@@ -371,7 +252,7 @@ static inline void _sm_update(const struct sm_inputs *in,
 		if (!arm_to_boost_conditions_met(in))
 			break;
 
-		SM_EVENT("orientation and altitude threshold reached");
+		sm_event("orientation and altitude threshold reached");
 		/* Conditions are met, so start the timer. */
 		k_timer_start(&dt_ab, K_MSEC(th.DT_AB), K_NO_WAIT);
 		running_timers[TIMER_DT_AB] = 1;
@@ -382,7 +263,7 @@ static inline void _sm_update(const struct sm_inputs *in,
 	*----------------------------------------------------------*/
 	case SM_BOOST:
 		if (in->acceleration < th.T_BB) {
-			SM_TRANSITION(SM_BURNOUT);
+			sm_transition(SM_BURNOUT);
 		}
 		break;
 
@@ -391,14 +272,14 @@ static inline void _sm_update(const struct sm_inputs *in,
 	*----------------------------------------------------------*/
 	case SM_BURNOUT:
 #if defined(CONFIG_FILTER)
-		if (filter_detect_apogee(&filter) == 1) {
+		if (sm_filter_detect_apogee() == 1) {
 			k_timer_start(&to_a, K_MSEC(th.TO_A), K_NO_WAIT);
-			SM_TRANSITION(SM_APOGEE);
+			sm_transition(SM_APOGEE);
 		}
 #else
 		if (in->velocity <= 0.0 && in->altitude < previous_altitude) {
 			k_timer_start(&to_a, K_MSEC(th.TO_A), K_NO_WAIT);
-			SM_TRANSITION(SM_APOGEE);
+			sm_transition(SM_APOGEE);
 		}
 #endif /* CONFIG_FILTER */
 		break;
@@ -410,11 +291,11 @@ static inline void _sm_update(const struct sm_inputs *in,
 		if (in->altitude < th.T_M) {
 			k_timer_stop(&to_a);
 			k_timer_start(&to_m, K_MSEC(th.TO_M), K_NO_WAIT);
-			SM_TRANSITION(SM_MAIN);
+			sm_transition(SM_MAIN);
 		} else if (TIMER_EXPIRED(&to_a)) {
 			/* Timeout expired, abort to ERROR */
 			k_timer_stop(&to_a);
-			SM_EVENT("apogee timeout expired");
+			sm_event("apogee timeout expired");
 			sm_do_error_handling(SM_ERR_APOGEE_TIMEOUT);
 		}
 		break;
@@ -426,7 +307,7 @@ static inline void _sm_update(const struct sm_inputs *in,
 		if (TIMER_EXPIRED(&to_m)) {
 			k_timer_stop(&to_m);
 			k_timer_start(&to_r, K_MSEC(th.TO_R), K_NO_WAIT);
-			SM_TRANSITION(SM_REDUNDANT);
+			sm_transition(SM_REDUNDANT);
 		}
 		break;
 
@@ -446,7 +327,7 @@ static inline void _sm_update(const struct sm_inputs *in,
 			/* At this point, conditions are met. Is the timer done as well? */
 			if (TIMER_EXPIRED(&dt_l)) {
 				/* Congrats! LANDING detected! */
-				SM_TRANSITION(SM_LANDED);
+				sm_transition(SM_LANDED);
 				k_timer_stop(&dt_l);
 				running_timers[TIMER_DT_L] = 0;
 				break;
@@ -470,7 +351,7 @@ _check_timeout:
 			k_timer_stop(&dt_l);
 			running_timers[TIMER_DT_L] = 0;
 			k_timer_stop(&to_r);
-			SM_EVENT("redundant timeout expired");
+			sm_event("redundant timeout expired");
 			sm_do_error_handling(SM_ERR_REDUNDANT_TIMEOUT);
 		}
 		break;
@@ -479,7 +360,7 @@ _check_timeout:
 	*----------------------------------------------------------*/
 	case SM_ERROR:
 		/* Try to fix the error; re-report the original cause. */
-		sm_do_error_handling(err_reason);
+		sm_error_retry();
 		break;
 
 	/*-----------------------------------------------------------
@@ -491,77 +372,14 @@ _check_timeout:
 	}
 }
 
-/* sm_update – see state.h */
-void sm_update(const struct sm_inputs *inputs)
-{
-	static double previous_altitude = 0.0;
-
-#if defined(CONFIG_FILTER)
-	static uint64_t last_time_ns = 0;
-	struct sm_inputs filtered_inputs;
-
-	uint64_t current_time_ns = k_ticks_to_ns_floor64(k_uptime_ticks());
-
-	if (last_time_ns != 0) {
-		filter_predict(&filter, current_time_ns - last_time_ns,
-			       inputs->accel_vert);
-		filter_update(&filter, inputs->altitude);
-	}
-	last_time_ns = current_time_ns;
-
-	filtered_inputs = *inputs;
-	filtered_inputs.altitude = filter.state[0];
-	filtered_inputs.velocity = filter.state[1];
-
-	_sm_update(&filtered_inputs, previous_altitude);
-	previous_altitude = filtered_inputs.altitude;
-	last_inputs = filtered_inputs;
-#else
-	_sm_update(inputs, previous_altitude);
-	previous_altitude = inputs->altitude;
-	last_inputs = *inputs;
-#endif /* CONFIG_FILTER */
-}
-
-/* sm_update_force – see state.h */
-void sm_update_force(enum sm_state transition_to)
-{
-	SM_TRANSITION(transition_to);
-}
-
-
 /*-----------------------------------------------------------
- * Getter
+ * Getters
  *----------------------------------------------------------*/
-
-/* sm_get_state – see state.h */
-enum sm_state sm_get_state(void)
-{
-	return current_state;
-}
 
 /* sm_get_type - see state.h */
 enum sm_type sm_get_type(void)
 {
 	return SM_TYPE_SIMPLE;
-}
-
-/* sm_get_inputs – see state.h */
-void sm_get_inputs(struct sm_inputs *out)
-{
-	*out = last_inputs;
-}
-
-/* sm_error_reason_str – see state.h */
-const char *sm_error_reason_str(enum sm_error_reason reason)
-{
-	switch (reason) {
-	case SM_ERR_UNKNOWN:		return "UNKNOWN";
-	case SM_ERR_LOG_OFFLINE:	return "LOG_OFFLINE";
-	case SM_ERR_APOGEE_TIMEOUT:	return "APOGEE_TIMEOUT";
-	case SM_ERR_REDUNDANT_TIMEOUT:	return "REDUNDANT_TIMEOUT";
-	default:			return "UNKNOWN";
-	}
 }
 
 /* sm_state_str – see simple.h */

--- a/lib/state/state.c
+++ b/lib/state/state.c
@@ -1,0 +1,255 @@
+/**
+ * @file state.c
+ * @brief Common core for the AURORA flight state machine.
+ *
+ * Implements the public API declared in state.h that is independent of any
+ * particular state machine implementation: lifecycle (init/deinit), the
+ * update entry point and its input filtering, the current-state accessor,
+ * and the error-handling machinery.  The backend-specific transition logic
+ * lives in a separate backend translation unit (e.g. simple.c) selected at
+ * build time; this core drives it through the sm_backend_* hooks and the
+ * backend drives this core back through sm_transition() / sm_event() /
+ * sm_do_error_handling().
+ *
+ * Copyright (c) 2025-2026, Auxspace e.V.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/spinlock.h>
+
+#include <aurora/lib/state/state.h>
+#include "state_internal.h"
+
+#if defined(CONFIG_AURORA_STATE_MACHINE_AUDIT)
+#include <aurora/lib/state/audit.h>
+#endif /* CONFIG_AURORA_STATE_MACHINE_AUDIT */
+
+#if defined(CONFIG_FILTER)
+#include <aurora/lib/filter.h>
+static struct filter filter;
+#endif /* CONFIG_FILTER */
+
+LOG_MODULE_REGISTER(state_machine, CONFIG_STATE_MACHINE_LOG_LEVEL);
+
+/*-----------------------------------------------------------
+ * Prototypes
+ *----------------------------------------------------------*/
+
+/**
+ * @brief Default error handler when no user callback is registered.
+ *
+ * @param reason Why the state machine entered SM_ERROR.
+ * @param args Unused opaque argument (always NULL).
+ * @return Always returns -EIO.
+ */
+static int fallback_sm_error_handler(enum sm_error_reason reason, void *args);
+
+/*-----------------------------------------------------------
+ * Internal State
+ *----------------------------------------------------------*/
+static enum sm_state current_state = SM_IDLE; /**< Active flight state. */
+static struct sm_inputs last_inputs; /**< Last inputs evaluated by the backend. */
+
+static struct k_spinlock err_lock; /**< Spinlock protecting error callback invocation. */
+static struct sm_error_handling_args err_hdl = {
+	.cb = &fallback_sm_error_handler,
+	.args = NULL,
+};
+
+/* Why the machine is (or last was) in SM_ERROR.  Recorded by
+ * sm_do_error_handling() so re-invocations from the SM_ERROR state keep
+ * reporting the original cause to the callback.
+ */
+static enum sm_error_reason err_reason = SM_ERR_UNKNOWN;
+
+/*-----------------------------------------------------------
+ * Transition / audit helpers (see state_internal.h)
+ *----------------------------------------------------------*/
+
+/* sm_transition – see state_internal.h */
+void sm_transition(enum sm_state new_state)
+{
+#if defined(CONFIG_AURORA_STATE_MACHINE_AUDIT)
+	sm_audit_transition(current_state, new_state);
+#endif /* CONFIG_AURORA_STATE_MACHINE_AUDIT */
+	current_state = new_state;
+}
+
+/* sm_event – see state_internal.h */
+void sm_event(const char *msg)
+{
+#if defined(CONFIG_AURORA_STATE_MACHINE_AUDIT)
+	sm_audit_event(current_state, msg);
+#else
+	ARG_UNUSED(msg);
+#endif /* CONFIG_AURORA_STATE_MACHINE_AUDIT */
+}
+
+/*-----------------------------------------------------------
+ * Error handling
+ *----------------------------------------------------------*/
+
+static int fallback_sm_error_handler(enum sm_error_reason reason, void *args)
+{
+	ARG_UNUSED(args);
+	LOG_ERR("State Machine encountered an unrecoverable error (%s)",
+		sm_error_reason_str(reason));
+
+	return -EIO;
+}
+
+/* sm_do_error_handling – see state_internal.h */
+void sm_do_error_handling(enum sm_error_reason reason)
+{
+	int ret;
+	k_spinlock_key_t key = k_spin_lock(&err_lock);
+
+	if (current_state != SM_ERROR) {
+		err_reason = reason;
+		sm_transition(SM_ERROR);
+	}
+
+	if (err_hdl.cb == NULL) {
+		LOG_ERR("No fallback handler defined for state machine errors!");
+		goto out;
+	}
+
+	ret = err_hdl.cb(err_reason, err_hdl.args);
+	if (ret == 0) {
+		sm_event("error mitigated, returning to IDLE");
+		sm_backend_stop_timers();
+		err_reason = SM_ERR_UNKNOWN;
+		sm_transition(SM_IDLE);
+	} else {
+		LOG_ERR("State Machine error handler failed with code %d", ret);
+	}
+
+out:
+	k_spin_unlock(&err_lock, key);
+}
+
+/* sm_error_retry – see state_internal.h */
+void sm_error_retry(void)
+{
+	/* Try to fix the error; re-report the original cause. */
+	sm_do_error_handling(err_reason);
+}
+
+#if defined(CONFIG_FILTER)
+/* sm_filter_detect_apogee – see state_internal.h */
+int sm_filter_detect_apogee(void)
+{
+	return filter_detect_apogee(&filter);
+}
+#endif /* CONFIG_FILTER */
+
+/*-----------------------------------------------------------
+ * Initialization / Deinitialization
+ *----------------------------------------------------------*/
+
+/* sm_init – see state.h */
+void sm_init(const struct sm_thresholds *cfg,
+	     struct sm_error_handling_args *sm_err_hdl)
+{
+#if defined(CONFIG_FILTER)
+	int ret = filter_init(&filter);
+	if (ret) {
+		LOG_ERR("Could not initialize filter (%d).", ret);
+		return;
+	}
+#endif /* CONFIG_FILTER */
+
+	sm_backend_init(cfg);
+	current_state = SM_IDLE;
+	err_reason = SM_ERR_UNKNOWN;
+	sm_event("state machine initialized");
+
+	if (sm_err_hdl != NULL) {
+		err_hdl.cb = sm_err_hdl->cb;
+		err_hdl.args = sm_err_hdl->args;
+	}
+}
+
+/* sm_deinit – see state.h */
+void sm_deinit(void)
+{
+	sm_backend_deinit();
+	memset(&last_inputs, 0, sizeof(last_inputs));
+	sm_event("state machine reset");
+	current_state = SM_IDLE;
+	err_reason = SM_ERR_UNKNOWN;
+}
+
+/*-----------------------------------------------------------
+ * Update
+ *----------------------------------------------------------*/
+
+/* sm_update – see state.h */
+void sm_update(const struct sm_inputs *inputs)
+{
+	static double previous_altitude = 0.0;
+
+#if defined(CONFIG_FILTER)
+	static uint64_t last_time_ns = 0;
+	struct sm_inputs filtered_inputs;
+
+	uint64_t current_time_ns = k_ticks_to_ns_floor64(k_uptime_ticks());
+
+	if (last_time_ns != 0) {
+		filter_predict(&filter, current_time_ns - last_time_ns,
+			       inputs->accel_vert);
+		filter_update(&filter, inputs->altitude);
+	}
+	last_time_ns = current_time_ns;
+
+	filtered_inputs = *inputs;
+	filtered_inputs.altitude = filter.state[0];
+	filtered_inputs.velocity = filter.state[1];
+
+	sm_backend_step(&filtered_inputs, previous_altitude);
+	previous_altitude = filtered_inputs.altitude;
+	last_inputs = filtered_inputs;
+#else
+	sm_backend_step(inputs, previous_altitude);
+	previous_altitude = inputs->altitude;
+	last_inputs = *inputs;
+#endif /* CONFIG_FILTER */
+}
+
+/* sm_update_force – see state.h */
+void sm_update_force(enum sm_state transition_to)
+{
+	sm_transition(transition_to);
+}
+
+/*-----------------------------------------------------------
+ * Getters
+ *----------------------------------------------------------*/
+
+/* sm_get_state – see state.h */
+enum sm_state sm_get_state(void)
+{
+	return current_state;
+}
+
+/* sm_get_inputs – see state.h */
+void sm_get_inputs(struct sm_inputs *out)
+{
+	*out = last_inputs;
+}
+
+/* sm_error_reason_str – see state.h */
+const char *sm_error_reason_str(enum sm_error_reason reason)
+{
+	switch (reason) {
+	case SM_ERR_UNKNOWN:		return "UNKNOWN";
+	case SM_ERR_LOG_OFFLINE:	return "LOG_OFFLINE";
+	case SM_ERR_APOGEE_TIMEOUT:	return "APOGEE_TIMEOUT";
+	case SM_ERR_REDUNDANT_TIMEOUT:	return "REDUNDANT_TIMEOUT";
+	default:			return "UNKNOWN";
+	}
+}

--- a/lib/state/state_internal.h
+++ b/lib/state/state_internal.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025-2026 Auxspace e.V.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef APP_LIB_STATE_INTERNAL_H_
+#define APP_LIB_STATE_INTERNAL_H_
+
+#include <aurora/lib/state/state.h>
+
+/**
+ * @file state_internal.h
+ * @brief Private contract between the common state core and a backend.
+ *
+ * The common core (state.c) implements the public API from state.h,
+ * owns the shared runtime state (current state, error handling, input
+ * filtering) and calls into the selected backend for the parts that
+ * genuinely differ per implementation (the transition logic and its
+ * private resources).  The backend, in turn, calls back into the core
+ * through the helpers below to change state, log events and raise errors.
+ *
+ * This header is internal to the state library: it is deliberately not
+ * installed under include/ and must not be used by application code.
+ *
+ * Backends are required to define an @c sm_state enum that includes at
+ * least @c SM_IDLE and @c SM_ERROR, since the common error path uses them.
+ */
+
+/*-----------------------------------------------------------
+ * Common core -> backend (defined by state.c)
+ *----------------------------------------------------------*/
+
+/**
+ * @brief Transition to @p new_state, recording it in the audit log first.
+ *
+ * This is the only sanctioned way to change the active state; it keeps
+ * the audit log and @ref sm_get_state() consistent.
+ *
+ * @param new_state State to transition to.
+ */
+void sm_transition(enum sm_state new_state);
+
+/**
+ * @brief Record a notable event against the current state in the audit log.
+ *
+ * @param msg Short event description (string literal or static storage).
+ */
+void sm_event(const char *msg);
+
+/**
+ * @brief Enter @c SM_ERROR for @p reason and run the error callback.
+ *
+ * Latches @p reason, transitions to @c SM_ERROR (if not already there)
+ * and invokes the registered error callback.  If the callback clears the
+ * error (returns 0) the core stops the backend timers and returns to
+ * @c SM_IDLE.  Safe to call repeatedly from the @c SM_ERROR state.
+ *
+ * @param reason Why the state machine is entering @c SM_ERROR.
+ */
+void sm_do_error_handling(enum sm_error_reason reason);
+
+/**
+ * @brief Re-run the error handler for the currently latched reason.
+ *
+ * Used by the backend's @c SM_ERROR case to keep retrying recovery while
+ * reporting the original cause.
+ */
+void sm_error_retry(void);
+
+#if defined(CONFIG_FILTER)
+/**
+ * @brief Query the input filter for apogee (descent onset).
+ *
+ * @retval 1 Apogee detected.
+ * @retval 0 Not yet.
+ */
+int sm_filter_detect_apogee(void);
+#endif /* CONFIG_FILTER */
+
+/*-----------------------------------------------------------
+ * Backend -> common core (defined by the selected backend)
+ *----------------------------------------------------------*/
+
+/**
+ * @brief Load @p cfg and initialise backend-private resources (timers, ...).
+ *
+ * @param cfg Threshold configuration to copy into the backend.
+ */
+void sm_backend_init(const struct sm_thresholds *cfg);
+
+/**
+ * @brief Release backend-private resources and clear loaded thresholds.
+ */
+void sm_backend_deinit(void);
+
+/**
+ * @brief Stop and clear all backend timers.
+ *
+ * Called by the common error path when recovering to @c SM_IDLE.
+ */
+void sm_backend_stop_timers(void);
+
+/**
+ * @brief Evaluate @p in against the flight logic and drive transitions.
+ *
+ * @param in                Current (already filtered, if enabled) inputs.
+ * @param previous_altitude Altitude from the previous update cycle (m).
+ */
+void sm_backend_step(const struct sm_inputs *in, double previous_altitude);
+
+#endif /* APP_LIB_STATE_INTERNAL_H_ */

--- a/sensor_board/src/data.h
+++ b/sensor_board/src/data.h
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 
 #include <aurora/lib/baro.h>
-#include <aurora/lib/state/simple.h>
+#include <aurora/lib/state/state.h>
 
 #if defined(CONFIG_DATA_LOGGER_BIN)
 void log_handle_flight_lifecycle(const enum sm_state prev_state, const enum sm_state state);


### PR DESCRIPTION
## Description

State machine functions should only be exposed by a single "state.h" header file instead of using "simple.h".

## Related Issues

Closes #163 

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `refactor` — no behavior change
- [ ] `build` / `ci` — build system or CI changes
- [ ] `tests` — adding or updating tests

## Testing

How was this tested? Which boards / targets were used?

- [x] `west twister -T tests -v --inline-logs` passes
- [ ] Tested on hardware: <!-- board name -->
- [x] Docs build without warnings: `cd doc && doxygen && make html`

## Checklist

- [x] Commit messages follow the [Conventional Commits + gitmoji](../CONTRIBUTING.md#commit-messages) style
- [x] New or changed public APIs have Doxygen comments
- [x] No unrelated changes are included
