### PR TITLE
docs: :memo: add links to releases and github sources

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -140,6 +140,147 @@ article .sidebar.board-overview {
     }
 }
 
+/* --- "Open on GitHub" link in the per-page top bar -------------------------
+ * Our _templates/components/view-this-page.html override renders a labelled
+ * GitHub link into Furo's .content-icon-container (the floated top-right action
+ * row that also holds the theme toggle and ToC icon), mirroring the "Open on
+ * GitHub" link in the Zephyr docs' top bar.  The container is shrink-to-fit
+ * (float:right), so the link simply sits at the left of that cluster. */
+.content-icon-container .open-on-github {
+    display: flex;
+    align-items: center;
+}
+
+.content-icon-container .open-on-github a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+    font-size: var(--font-size--small);
+    white-space: nowrap;
+}
+
+.content-icon-container .open-on-github svg {
+    width: 1.15em;
+    height: 1.15em;
+}
+
+/* Hide the text label on narrow content so only the GitHub mark shows. */
+@media (max-width: 46em) {
+    .content-icon-container .open-on-github .open-on-github-label {
+        display: none;
+    }
+}
+
+/* --- "Releases" dropdown pinned to the bottom of the sidebar ---------------
+ * Rendered by _templates/sidebar/aurora-version.html, placed after
+ * sidebar/scroll-end.html so it sits below the scrolling nav, mirroring the
+ * version selector in the Zephyr docs.  A native <details> disclosure whose
+ * menu opens *upward* (bottom: 100%) so it overlays the nav instead of
+ * overflowing past the bottom of the viewport. */
+.sidebar-releases {
+    position: relative;
+    flex-shrink: 0;
+    border-top: 1px solid var(--color-sidebar-background-border);
+    background: var(--color-sidebar-background);
+}
+
+/* Summary = the always-visible button row. */
+.sidebar-releases-summary {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    color: var(--color-sidebar-link-text);
+    font-size: var(--sidebar-item-font-size, 0.9em);
+    user-select: none;
+    list-style: none;            /* hide the default disclosure triangle */
+}
+
+.sidebar-releases-summary::-webkit-details-marker {
+    display: none;               /* hide it in WebKit/Blink too */
+}
+
+.sidebar-releases-summary:hover {
+    color: var(--color-sidebar-link-text--top-level);
+    background: var(--color-sidebar-item-background--hover);
+}
+
+.sidebar-releases-icon {
+    width: 1.1em;
+    height: 1.1em;
+    flex-shrink: 0;
+}
+
+.sidebar-releases-label {
+    font-weight: 600;
+}
+
+.sidebar-releases-caret {
+    width: 0.9em;
+    height: 0.9em;
+    margin-left: auto;
+    opacity: 0.7;
+    transition: transform 0.15s ease;
+}
+
+.sidebar-releases-details[open] .sidebar-releases-caret {
+    transform: rotate(180deg);
+}
+
+/* The version/downloads menu, opening upward over the navigation.  Split into
+ * labelled sections (like the Zephyr flyout), each holding a wrapping row of
+ * links. */
+.sidebar-releases-menu {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 100%;
+    z-index: 10;
+    margin: 0 0.5rem 0.25rem;
+    padding: 0.6rem 0.85rem;
+    border: 1px solid var(--color-sidebar-background-border);
+    border-radius: 0.3rem;
+    background: var(--color-sidebar-background);
+    box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.18);
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.sidebar-releases-section + .sidebar-releases-section {
+    margin-top: 0.7rem;
+}
+
+.sidebar-releases-heading {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--color-brand-primary);
+    font-weight: 600;
+    font-size: 0.78em;
+}
+
+.sidebar-releases-items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem 0.8rem;
+}
+
+.sidebar-releases-item {
+    color: var(--color-sidebar-link-text);
+    text-decoration: none;
+    font-size: var(--sidebar-item-font-size, 0.9em);
+    white-space: nowrap;
+}
+
+.sidebar-releases-item:hover {
+    color: var(--color-brand-content);
+    text-decoration: underline;
+}
+
+.sidebar-releases-item--muted {
+    opacity: 0.7;
+}
+
 /* Bridge Zephyr board.css CSS variable names to Furo's equivalents so that
  * zephyr:board-supported-hw and zephyr:board-supported-runners render
  * correctly under the Furo theme. */

--- a/doc/_templates/components/view-this-page.html
+++ b/doc/_templates/components/view-this-page.html
@@ -1,0 +1,22 @@
+{#- Override Furo's per-page "view source" button (rendered into the
+    content-icon-container top bar) to show a labelled "Open on GitHub" link.
+
+    We reuse basic-ng's block gating (link_available fires when a view link is
+    considered available, i.e. source_repository/source_branch are set in
+    conf.py) but ignore its computed URL in favour of `aurora_github_url`, which
+    conf.py's _add_aurora_github_url() sets per page so board doc pages reached
+    through the doc/boards symlink resolve correctly too. -#}
+{% extends "basic-ng/components/view-this-page.html" %}
+
+{%- macro aurora_github_button(url) -%}
+<div class="view-this-page open-on-github">
+  <a class="muted-link" href="{{ url }}" title="{{ _('Open this page on GitHub') }}">
+    <svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+    <span class="open-on-github-label">{{ _('Open on GitHub') }}</span>
+  </a>
+</div>
+{%- endmacro -%}
+
+{% block link_available -%}
+{{ aurora_github_button(aurora_github_url) }}
+{%- endblock %}

--- a/doc/_templates/sidebar/aurora-version.html
+++ b/doc/_templates/sidebar/aurora-version.html
@@ -1,0 +1,38 @@
+{#- "Releases" dropdown pinned to the bottom of the sidebar, modelled on the
+    Zephyr docs' version flyout.  Native <details> disclosure (no JavaScript):
+    the summary toggles a menu that opens upward and is split into sections:
+      * "Aurora Release Versions" - "latest" plus every tag in `aurora_releases`
+        (maintained in conf.py), each linking to its GitHub release page, and a
+        muted "all" link to the full releases listing.
+      * "Downloads" - a link to the PDF build of these docs (aurora_pdf_path,
+        resolved relative to the site root via pathto(); the docs deploy must
+        place the simplepdf output there).
+    It sits after sidebar/scroll-end.html (see html_sidebars in conf.py) so it
+    stays fixed at the bottom. -#}
+<div class="sidebar-releases">
+  <details class="sidebar-releases-details">
+    <summary class="sidebar-releases-summary">
+      <svg class="sidebar-releases-icon" viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M1 7.775V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 0 1 0 2.474l-5.026 5.026a1.75 1.75 0 0 1-2.474 0l-6.25-6.25A1.752 1.752 0 0 1 1 7.775Zm1.5 0c0 .066.026.13.073.177l6.25 6.25a.25.25 0 0 0 .354 0l5.025-5.025a.25.25 0 0 0 0-.354l-6.25-6.25a.25.25 0 0 0-.177-.073H2.75a.25.25 0 0 0-.25.25ZM6 5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z"/></svg>
+      <span class="sidebar-releases-label">{{ _('Releases') }}</span>
+      <svg class="sidebar-releases-caret" viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M12.78 6.22a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L3.22 7.28a.75.75 0 0 1 1.06-1.06L8 9.94l3.72-3.72a.75.75 0 0 1 1.06 0Z"/></svg>
+    </summary>
+    <div class="sidebar-releases-menu">
+      <div class="sidebar-releases-section">
+        <span class="sidebar-releases-heading">{{ _('Aurora Release Versions') }}</span>
+        <div class="sidebar-releases-items">
+          <a class="sidebar-releases-item" href="{{ aurora_releases_url }}/latest">{{ _('latest') }}</a>
+          {%- for release_tag in aurora_releases %}
+          <a class="sidebar-releases-item" href="{{ aurora_releases_tag_base }}/{{ release_tag }}">{{ release_tag }}</a>
+          {%- endfor %}
+          <a class="sidebar-releases-item sidebar-releases-item--muted" href="{{ aurora_releases_url }}">{{ _('all') }}</a>
+        </div>
+      </div>
+      <div class="sidebar-releases-section">
+        <span class="sidebar-releases-heading">{{ _('Downloads') }}</span>
+        <div class="sidebar-releases-items">
+          <a class="sidebar-releases-item" href="{{ pathto(aurora_pdf_path, 1) }}">{{ _('PDF') }}</a>
+        </div>
+      </div>
+    </div>
+  </details>
+</div>

--- a/doc/applications/index.md
+++ b/doc/applications/index.md
@@ -3,6 +3,10 @@
 As stated on the main page, AURORA contains out of the box applications for
 model rocketry.
 
+The application code lives in the top-level directories of the
+[`aurora`](https://github.com/AUXSPACEeV/aurora) repository, e.g.
+[`sensor_board`](https://github.com/AUXSPACEeV/aurora/tree/main/sensor_board).
+
 ```{toctree}
 :maxdepth: 2
 

--- a/doc/applications/sensor_board.md
+++ b/doc/applications/sensor_board.md
@@ -1,5 +1,7 @@
 # Sensor Board
 
+**Source:** [`sensor_board`](https://github.com/AUXSPACEeV/aurora/tree/main/sensor_board)
+
 The sensor board application is a simple flight computer for model rocketry.
 
 AURORA is built to run on multiple interconnected PCBs that communicate over CAN

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,6 +4,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -182,6 +183,84 @@ gh_link_prefixes = {
     ".*": "doc",
 }
 
+# -- Repo / release links in the Furo chrome ---------------------------------
+# Two additions modelled on the Zephyr docs chrome:
+#   1. An "Open on GitHub" link in the per-page top bar.  Furo renders
+#      components/view-this-page.html into the content-icon-container when
+#      "view" is listed in top_of_page_buttons (see html_theme_options above);
+#      _templates/components/view-this-page.html overrides it to render a
+#      labelled GitHub link using the per-page URL computed by
+#      _add_aurora_github_url() below.
+#   2. A "Releases" entry pinned to the bottom of the sidebar, rendered by
+#      _templates/sidebar/aurora-version.html and wired in via html_sidebars.
+#
+# source_repository/branch are required so that basic-ng's view component
+# considers a view link "available" (which gates the link_available block our
+# override fills); the URL itself is recomputed per page to also cover board
+# doc pages reached through the doc/boards/ symlink.
+html_theme_options["source_repository"] = gh_link_base_url + "/"
+html_theme_options["source_branch"]     = gh_link_version
+html_theme_options["source_directory"]  = "doc/"
+
+# Consumed by _templates/sidebar/aurora-version.html.  The release list is
+# maintained by hand -- add each new release tag to the TOP (newest first); the
+# sidebar dropdown turns every entry into a link to its GitHub release page
+# ({gh_link_base_url}/releases/tag/<tag>).
+_AURORA_RELEASES = [
+    "v0.4.2",
+    "v0.3.2",
+]
+html_context = {
+    "aurora_releases": _AURORA_RELEASES,
+    "aurora_releases_url": gh_link_base_url + "/releases",
+    "aurora_releases_tag_base": gh_link_base_url + "/releases/tag",
+    # Site-root-relative path to the PDF build of the docs (produced by
+    # `make simplepdf` / sphinx-simplepdf, see simplepdf_file_name).  The HTML
+    # build does not generate it, so the docs deploy must copy the simplepdf
+    # output to this location; the sidebar "Downloads > PDF" link resolves it
+    # relative to each page via pathto().
+    "aurora_pdf_path": simplepdf_file_name,
+}
+
+# Pin the "Releases" entry to the bottom of the sidebar by appending it after
+# sidebar/scroll-end.html: everything after the scroll container is rendered
+# outside the scroll area, so it sticks to the bottom.  Setting html_sidebars
+# replaces Furo's defaults wholesale, so the default sections (copied from
+# Furo's theme.conf) must be repeated here.
+html_sidebars = {
+    "**": [
+        "sidebar/brand.html",
+        "sidebar/search.html",
+        "sidebar/scroll-start.html",
+        "sidebar/navigation.html",
+        "sidebar/ethical-ads.html",
+        "sidebar/scroll-end.html",
+        "sidebar/aurora-version.html",
+        "sidebar/variant-selector.html",
+    ]
+}
+
+
+def _add_aurora_github_url(app, pagename, templatename, context, doctree):
+    """Expose a correct per-page GitHub "blob" URL as ``aurora_github_url``.
+
+    basic-ng's built-in view link assumes every page lives under doc/, but
+    board doc pages are reached through the doc/boards -> ../boards symlink and
+    live at boards/... in the repo (mirroring gh_link_prefixes).  Compute the
+    URL here so the top-bar "Open on GitHub" link resolves for both.
+    """
+    try:
+        src_rel = os.path.relpath(app.env.doc2path(pagename), app.srcdir)
+    except Exception:
+        context["aurora_github_url"] = gh_link_base_url
+        return
+    src_rel = src_rel.replace(os.sep, "/")
+    # boards/* map to the repo root; everything else lives under doc/.
+    repo_path = src_rel if src_rel.startswith("boards/") else "doc/" + src_rel
+    context["aurora_github_url"] = (
+        f"{gh_link_base_url}/blob/{gh_link_version}/{repo_path}"
+    )
+
 # -- Zephyr domain tweaks ----------------------------------------------------
 # gen_boards_catalog.guess_image makes board image paths relative to ZEPHYR_BASE,
 # which fails for Aurora's own boards that live outside the Zephyr tree.
@@ -353,6 +432,24 @@ import zephyr.domain as _zd
 from docutils import nodes as _nodes
 _zd.BINDING_TYPE_TO_DOCUTILS_NODE["pyro"] = _nodes.Text("Pyrotechnic Ignition")
 
+# gh_utils.gh_link_get_url() builds the URL by joining
+# base/mode/version/prefix/doc-path with "/".  Aurora's board pages resolve to
+# an *empty* gh_link prefix (see gh_link_prefixes), so the join leaves a "//" in
+# the path (e.g. .../blob/<ver>//boards/...), which breaks the board GitHub
+# links (the "Browse board sources" button etc.).  Wrap the function -- the name
+# the domain module actually calls -- to collapse duplicate slashes in the path
+# while preserving the scheme's "//".
+_orig_gh_link_get_url = _zd.gh_link_get_url
+
+def _gh_link_get_url_clean(app, pagename, mode="blob"):
+    url = _orig_gh_link_get_url(app, pagename, mode)
+    if not url:
+        return url
+    scheme, sep, rest = url.partition("://")
+    return scheme + sep + re.sub(r"/{2,}", "/", rest)
+
+_zd.gh_link_get_url = _gh_link_get_url_clean
+
 # Board status registry: board_id -> (display_name, status_string)
 # Extend this dict when new boards are added or maintenance status changes.
 _AURORA_BOARD_STATUS = {
@@ -373,6 +470,26 @@ def _convert_board_node_with_status(self):
         docname = self.document.settings.env.docname
     except AttributeError:
         docname = ""
+
+    # Rewrite the "Browse board sources" button (added by ConvertBoardNode) to a
+    # clean directory URL.  Upstream builds href="{gh_link}/../..", which points
+    # a blob URL at the board's doc file and then walks up two levels with
+    # "/../.." -- a path only the browser normalises, and only after GitHub
+    # redirects blob->tree.  Point it straight at the board directory instead.
+    env = self.document.settings.env
+    try:
+        src_rel = os.path.relpath(env.doc2path(docname), env.srcdir).replace(os.sep, "/")
+    except Exception:
+        src_rel = ""
+    board_dir = "/".join(src_rel.split("/")[:-2])  # strip the "/doc/<page>" tail
+    if board_dir:
+        clean_url = f"{gh_link_base_url}/tree/{gh_link_version}/{board_dir}"
+        for raw in self.document.traverse(_nodes.raw):
+            if "board-github-link" not in raw.astext():
+                continue
+            fixed = re.sub(r'href="[^"]*"', f'href="{clean_url}"', raw.astext(), count=1)
+            raw.replace_self(_nodes.raw("", fixed, format="html"))
+            break
 
     status_text = next(
         (status for board_id, (_, status) in _AURORA_BOARD_STATUS.items()
@@ -449,6 +566,7 @@ def _on_doctree_resolved(app, doctree, docname):
 
 def setup(app):
     app.connect("doctree-resolved", _on_doctree_resolved)
+    app.connect("html-page-context", _add_aurora_github_url)
 
 # -- Zephyr domain board features --------------------------------------------
 # Run CMake-only twister pass for Aurora's boards so that board-supported-hw

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -6,6 +6,11 @@ In the [AURORA git repository's README](https://github.com/AUXSPACEeV/aurora)
 and the {external+zephyr:ref}`getting_started` guide from `zephyr` is everything
 you need to install first.
 
+```{note}
+Tagged builds are published on the
+[GitHub releases page](https://github.com/AUXSPACEeV/aurora/releases/latest).
+```
+
 AURORA is built inside a `west` workspace.
 The directory layout is:
 

--- a/doc/tools/gen_flight_replay.md
+++ b/doc/tools/gen_flight_replay.md
@@ -1,5 +1,7 @@
 # gen_flight_replay.py
 
+**Source:** [`tools/gen_flight_replay.py`](https://github.com/AUXSPACEeV/aurora/blob/main/tools/gen_flight_replay.py)
+
 Convert a recorded AURORA flight CSV into a generated C source file that
 embeds the samples as constant arrays. The generated file is compiled into
 the firmware and consumed by the **replay backend** of `fake_sensors`, so

--- a/doc/tools/pad_link_central_example.md
+++ b/doc/tools/pad_link_central_example.md
@@ -1,5 +1,7 @@
 # pad_link_central_example.py
 
+**Source:** [`tools/pad_link_central_example.py`](https://github.com/AUXSPACEeV/aurora/blob/main/tools/pad_link_central_example.py)
+
 Minimal BLE central for the AURORA pad-link.
 
 This script is the smallest thing that talks to a rocket running

--- a/doc/tools/plot_flight_data.md
+++ b/doc/tools/plot_flight_data.md
@@ -1,5 +1,7 @@
 # plot_flight_data.py
 
+**Source:** [`tools/plot_flight_data.py`](https://github.com/AUXSPACEeV/aurora/blob/main/tools/plot_flight_data.py)
+
 Plot AURORA flight data — recorded telemetry from the flight computer
 or simulated streams produced by
 [`sim_flight_kalman.py`](sim_flight_kalman.md).

--- a/doc/tools/rec_zephyr.md
+++ b/doc/tools/rec_zephyr.md
@@ -1,5 +1,7 @@
 # rec_zephyr.py
 
+**Source:** [`tools/rec_zephyr.py`](https://github.com/AUXSPACEeV/aurora/blob/main/tools/rec_zephyr.py)
+
 MicroPython-based ground station for receiving AURORA telemetry over an
 HC-12 radio link during bench tests.
 

--- a/doc/tools/sim_fetch.md
+++ b/doc/tools/sim_fetch.md
@@ -1,5 +1,7 @@
 # sim_fetch.py
 
+**Source:** [`tools/sim_fetch.py`](https://github.com/AUXSPACEeV/aurora/blob/main/tools/sim_fetch.py)
+
 Extract a file from a running `native_sim` Zephyr instance.
 
 ## Background

--- a/doc/tools/sim_flight_kalman.md
+++ b/doc/tools/sim_flight_kalman.md
@@ -1,5 +1,7 @@
 # sim_flight_kalman.py
 
+**Source:** [`tools/sim_flight_kalman.py`](https://github.com/AUXSPACEeV/aurora/blob/main/tools/sim_flight_kalman.py)
+
 Run a synthetic rocket flight through a Python mirror of the AURORA
 Kalman filter and plot the result.
 

--- a/doc/tools/sweep_apogee.md
+++ b/doc/tools/sweep_apogee.md
@@ -1,5 +1,7 @@
 # sweep_apogee.py
 
+**Source:** [`tools/sweep_apogee.py`](https://github.com/AUXSPACEeV/aurora/blob/main/tools/sweep_apogee.py)
+
 Grid-search Kalman filter tuning parameters against recorded flights.
 
 ## What it does

--- a/doc/tools/sync_defconfig.md
+++ b/doc/tools/sync_defconfig.md
@@ -1,5 +1,7 @@
 # sync_defconfig.py
 
+**Source:** [`tools/sync_defconfig.py`](https://github.com/AUXSPACEeV/aurora/blob/main/tools/sync_defconfig.py)
+
 Merge the Zephyr-generated `defconfig` into a board-specific `.conf`.
 
 ## What it does

--- a/flight_logs/multimeter/flight_logs.md
+++ b/flight_logs/multimeter/flight_logs.md
@@ -1,5 +1,7 @@
 # MULTIMETER Flight Logs
 
+**Source:** [`flight_logs/multimeter`](https://github.com/AUXSPACEeV/aurora/tree/main/flight_logs/multimeter)
+
 The M.E.T.A. rocket has its purpose in testing the avionics system for the
 MULTIMETER project.
 Here are the test flights of M.E.T.A. archived and open for everyone to see:

--- a/flight_logs/sim_fetch/flight_sim.md
+++ b/flight_logs/sim_fetch/flight_sim.md
@@ -1,5 +1,7 @@
 # Flight Simulation
 
+**Source:** [`flight_logs/sim_fetch`](https://github.com/AUXSPACEeV/aurora/tree/main/flight_logs/sim_fetch)
+
 ## Info
 
 - AURORA Version: `0.2.1`


### PR DESCRIPTION
This commit is almost 100% claude's doing because we are in a deep hurry and flagged the docs to be non-critical.

## Description

Add links to releases and github sources.

## Related Issues

Closes #154 

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `refactor` — no behavior change
- [ ] `build` / `ci` — build system or CI changes
- [ ] `tests` — adding or updating tests

## Testing

How was this tested? Which boards / targets were used?

- [x] Docs build without warnings: `cd doc && make html`

## Checklist

- [x] Commit messages follow the [Conventional Commits + gitmoji](../CONTRIBUTING.md#commit-messages) style
- [x] New or changed public APIs have Doxygen comments
- [x] No unrelated changes are included
