### PR TITLE
fix(imu): :bug: Take the imu thread to sleep if init fails

### DIFF
--- a/lib/sensor/imu.c
+++ b/lib/sensor/imu.c
@@ -127,6 +127,10 @@ int imu_poll(const struct device *dev)
 /* imu_init – see imu.h */
 int imu_init(const struct device *dev)
 {
+	if (dev == NULL) {
+		LOG_ERR("IMU (NULL): device not ready");
+		return -ENODEV;
+	}
 	if (!device_is_ready(dev)) {
 		LOG_ERR("%s: device not ready", dev->name);
 		return -ENODEV;

--- a/sensor_board/src/main.c
+++ b/sensor_board/src/main.c
@@ -141,7 +141,9 @@ void imu_task(void *, void *, void *)
 
 	if (imu_init(imu0)) {
 		LOG_ERR("IMU not ready!");
-		return;
+		while (1) {
+			k_sleep(K_FOREVER);
+		}
 	}
 	imu_active = true;
 


### PR DESCRIPTION
## Description

What does this PR do and why?
Take the imu thread to sleep instead of returning.
See #182 for more details.
Stable for at least 10 min
```bash
uart:~$ date get
1970-01-01 00:00:13 UTC
uart:~$ date get
1970-01-01 00:03:41 UTC
uart:~$ date get
1970-01-01 00:11:34 UTC
uart:~$
```

## Related Issues

Closes #182 

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behavior change
- [ ] `build` / `ci` — build system or CI changes
- [ ] `tests` — adding or updating tests

## Testing

How was this tested? Which boards / targets were used?

- [ ] `west twister -T tests -v --inline-logs` passes
- [x] Tested on hardware: Micrometer v2
- [ ] Docs build without warnings: `cd doc && make html`

## Checklist

- [x] Commit messages follow the [Conventional Commits + gitmoji](../CONTRIBUTING.md#commit-messages) style
- [x] New or changed public APIs have Doxygen comments
- [x] No unrelated changes are included
